### PR TITLE
Allow custom styling with className prop

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 class ProgressBar extends React.Component {
   static propTypes = {
+    className: React.PropTypes.string,
     percent: React.PropTypes.number.isRequired,
     onTop: React.PropTypes.bool,
     autoIncrement: React.PropTypes.bool,
@@ -79,7 +80,7 @@ class ProgressBar extends React.Component {
   render() {
     let {onTop, spinner} = this.props;
     let {percent} = this.state;
-    let className = classnames('react-progress-bar', {
+    let className = classnames('react-progress-bar', this.props.className, {
       'react-progress-bar-on-top': onTop,
       'react-progress-bar-hide': percent < 0 || percent >= 100
     });


### PR DESCRIPTION
This commit adds the prop 'className' to the ProgressBar component.
Using this prop, the main progress bar div can be further styled (for example, setting the 'top' property to control the height)
